### PR TITLE
feat(eval): add method `lookup_local` which does not mark it as used

### DIFF
--- a/eval/src/compiler/bindings.rs
+++ b/eval/src/compiler/bindings.rs
@@ -699,9 +699,9 @@ impl Compiler<'_, '_> {
     }
 
     /// Is the given identifier defined *by the user* in any current scope?
-    pub(super) fn is_user_defined(&mut self, ident: &str) -> bool {
+    pub(super) fn is_user_defined(&self, ident: &str) -> bool {
         matches!(
-            self.scope_mut().resolve_local(ident),
+            self.scope().lookup_local(ident),
             LocalPosition::Known(_) | LocalPosition::Recursive(_)
         )
     }


### PR DESCRIPTION
The optimiser checks, whether `true` or `false` is user-defined here: https://github.com/tvlfyi/tvix/blob/canon/eval/src/compiler/optimiser.rs#L42

However, by calling `is_user_defined`, https://github.com/tvlfyi/tvix/blob/canon/eval/src/compiler/bindings.rs#L702 will call `resolve_local` which will mark the local as as used in https://github.com/tvlfyi/tvix/blob/canon/eval/src/compiler/scope.rs#L214. However, this will mark `true` as used, even if it was not used in a binary operator, e.g.:

```
warning[W004]: declared variable 'true' shadows a built-in global!
 --> [code]:1:5
  |
1 | let true = 23; in false
  |     ^^^^ variable declared here

warning[W003]: variable 'true' is declared, but never used:
 --> [code]:1:5
  |
1 | let true = 23; in false
  |     ^^^^ variable declared here

=> false :: bool
tvix-repl> let true = 23; in false && 42
⠁ Evaluating…                                                                                                                            (0s)       0/0      warning[W004]: declared variable 'true' shadows a built-in global!
 --> [code]:1:5
  |
1 | let true = 23; in false && 42
  |     ^^^^ variable declared here

=> false :: bool
tvix-repl> 
```

This PR introduces a new method `lookup_local` similar to `resolve_local`, but without marking it as used.

Apart from this issue, `c.is_user_defined("true") || c.is_user_defined("false")` should be fixed in another PR: Just because `true` was overridden, `false && 42` can perfectly be optimised:

```
warning[W007]: useless operation on boolean: this expression is always false
 --> [code]:1:1
  |
1 | false && 23
  | ^^^^^^^^^^^

=> false :: bool
tvix-repl> 
```

Note that this warning is missing in the repl above.

However, this is beyond the scope of this PR.