### PR TITLE
chore(nix-compat): make mimalloc dependency optional

### DIFF
--- a/nix-compat/Cargo.toml
+++ b/nix-compat/Cargo.toml
@@ -14,7 +14,7 @@ daemon = ["tokio", "nix-compat-derive", "futures"]
 test = []
 
 # Enable all features by default.
-default = ["async", "daemon", "wire", "nix-compat-derive"]
+default = ["async", "daemon", "wire", "nix-compat-derive", "mimalloc"]
 
 [dependencies]
 bitflags.workspace = true
@@ -24,7 +24,7 @@ ed25519.workspace = true
 ed25519-dalek.workspace = true
 
 futures = { workspace = true, optional = true }
-mimalloc.workspace = true
+mimalloc = { workspace = true, optional = true }
 nom.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true

--- a/nix-compat/src/bin/drvfmt.rs
+++ b/nix-compat/src/bin/drvfmt.rs
@@ -3,10 +3,13 @@ use std::{collections::BTreeMap, io::Read};
 use nix_compat::derivation::Derivation;
 use serde_json::json;
 
-use mimalloc::MiMalloc;
+#[cfg(feature = "mimalloc")]
+mod alloc {
+    use mimalloc::MiMalloc;
 
-#[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+    #[global_allocator]
+    static GLOBAL: MiMalloc = MiMalloc;
+}
 
 /// construct a serde_json::Value from a Derivation.
 /// Some environment values can be non-valid UTF-8 strings.


### PR DESCRIPTION
Dependency minimalism, as talked on matrix.

(Using a `mod` for this might be non-standard, but I didn't want to add `cfg_if` (transitive dependency already, still), to make a dependency optional.)